### PR TITLE
Fix issue with logs not found in the same place on different versions of Selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ There are three clues included:
 `with_clues` is intended as a diagnostic tool you can develop and enhance over time.  As your team writes more code or develops
 more conventions, you can develop diagnostics as well.
 
-To add one, create a class that implements `dump(notifier, context:)`:
+To add one, create a class that implements `dump(notifier, context:)` or `dump(notifier, context:, page:)`:
 
 * `notifier` is a `WithClues::Notifier` that you should use to produce output:
   * `notify` - output text, preceded with `[ with_clues ]` (this is so you can tell output from your code vs from `with_clues`)
   * `blank_line` - a blank line (no prefix)
   * `notify_raw` - output text without a prefix, useful for removing ambiguity about what is being output
 * `context:` the context passed into `with_clues` (nil if it was omitted)
+* `page:` If `dump` requires this keyword, your clue will only be used in a browser context when the Capybara `page` object is available.
+In that case, that is what is passed in.
 
 For example, suppose you want to output information about an Active Record like so:
 
@@ -152,6 +154,9 @@ WithClues::Method.use_custom_clue ActiveRecordClues
 ```
 
 You can use multiple clues by repeatedly calling `use_custom_clue`
+
+Note that if your clue implements the three-arg version of `dump` ( `dump(notifier, context:, page:)` ), it will *only* be used when in
+a context where Capybara's `page` element in in play.
 
 ## Developing
 

--- a/lib/with_clues/browser_logs.rb
+++ b/lib/with_clues/browser_logs.rb
@@ -6,24 +6,35 @@ module WithClues
         return
       end
       if page.driver.respond_to?(:browser)
-        if page.driver.browser.respond_to?(:manage)
-          if page.driver.browser.manage.respond_to?(:logs)
-            logs = page.driver.browser.manage.logs
-            browser_logs = logs.get(:browser)
-            notifier.notify "BROWSER LOGS {"
-            browser_logs.each do |log|
-              notifier.notify_raw log.message
-            end
-            notifier.notify "} END BROWSER LOGS"
-          else
-            notifier.notify "NO BROWSER LOGS: page.driver.browser.manage #{page.driver.browser.manage.class} does not respond to #logs"
+        logs = locate_logs(page.driver.browser, notifier: notifier)
+        if !logs.nil?
+          browser_logs = logs.get(:browser)
+          notifier.notify "BROWSER LOGS {"
+          browser_logs.each do |log|
+            notifier.notify_raw log.message
           end
-        else
-          notifier.notify "NO BROWSER LOGS: page.driver.browser #{page.driver.browser.class} does not respond to #manage"
+          notifier.notify "} END BROWSER LOGS"
         end
       else
         notifier.notify "NO BROWSER LOGS: page.driver #{page.driver.class} does not respond to #browser"
       end
     end
+
+  private
+
+    def locate_logs(browser, notifier:)
+      if browser.respond_to?(:manage)
+        if browser.manage.respond_to?(:logs)
+          return browser.manage.logs
+        end
+        notifier.notify "NO BROWSER LOGS: page.driver.browser.manage #{browser.manage.class} does not respond to #logs"
+      elsif browser.respond_to?(:logs)
+        return browser.logs
+      else
+        notifier.notify "NO BROWSER LOGS: page.driver.browser #{browser.class} does not respond to #manage or #logs"
+      end
+      nil
+    end
+
   end
 end

--- a/lib/with_clues/method.rb
+++ b/lib/with_clues/method.rb
@@ -1,6 +1,7 @@
 require_relative "html"
 require_relative "browser_logs"
 require_relative "notifier"
+require_relative "private/custom_clue_method_analysis"
 
 module WithClues
   module Method
@@ -23,18 +24,25 @@ module WithClues
       @@clue_classes[:custom].each do |klass|
         klass.new.dump(notifier, context: context)
       end
-      if !defined?(page)
-        raise ex
-      end
-      notifier.notify "Test failed: #{ex.message}"
-      @@clue_classes[:require_page].each do |klass|
-        klass.new.dump(notifier, context: context, page: page)
+      if defined?(page)
+        notifier.notify "Test failed: #{ex.message}"
+        @@clue_classes[:require_page].each do |klass|
+          klass.new.dump(notifier, context: context, page: page)
+        end
       end
       raise ex
     end
 
     def self.use_custom_clue(klass)
-      @@clue_classes[:custom] << klass
+      dump_method = klass.instance_method(:dump)
+      analysis = WithClues::Private::CustomClueMethodAnalysis.from_method(dump_method)
+      if analysis.standard_implementation?
+        @@clue_classes[:custom] << klass
+      elsif analysis.requires_page_object?
+        @@clue_classes[:require_page] << klass
+      else
+        analysis.raise_exception!
+      end
     end
   end
 end

--- a/lib/with_clues/private/custom_clue_method_analysis.rb
+++ b/lib/with_clues/private/custom_clue_method_analysis.rb
@@ -1,0 +1,139 @@
+module WithClues
+  module Private
+    class CustomClueMethodAnalysis
+
+      def self.from_method(unbound_method)
+
+        params = unbound_method.parameters.map { |param_array| Param.new(param_array) }
+
+        if params.size == 2
+          two_arg_method = TwoArgMethod.new(params)
+          if two_arg_method.valid?
+            return StandardImplementation.new
+          end
+
+          return BadParams.new(two_arg_method.errors)
+
+        elsif params.size == 3
+          three_arg_method = ThreeArgMethod.new(params)
+          if three_arg_method.valid?
+            return RequiresPageObject.new
+          end
+          return BadParams.new(three_arg_method.errors)
+        end
+
+        BadParams.new([])
+      end
+
+      def standard_implementation?
+        false
+      end
+
+      def requires_page_object?
+        false
+      end
+
+      def raise_exception!
+        raise StandardError.new("Unimplemented condition found inside #from_method")
+      end
+
+      class Param
+
+        def initialize(method_param_array)
+          @type = method_param_array[0]
+          @name = method_param_array[1]
+
+        end
+
+        def required?
+          @type == :req
+        end
+        def keyword_required?
+          @type == :keyreq
+        end
+
+        def named?(*allowed_names)
+          allowed_names.include?(@name)
+        end
+        def name
+          if self.keyword_required?
+            "#{@name}:"
+          else
+            @name
+          end
+        end
+      end
+
+      class TwoArgMethod
+        attr_reader :errors
+        def initialize(params)
+          @errors = []
+          if !params[0].required?
+            @errors << "Param 1, #{params[0].name}, is not required"
+          end
+          require_keyword(2,params[1])
+        end
+
+        def valid?
+          @errors.empty?
+        end
+      private
+
+        def require_keyword(param_number, param)
+          if !param.keyword_required?
+            @errors << "Param #{param_number}, #{param.name}, is not a required keyword param"
+          end
+          if !param.named?(*allowed_names)
+            @errors << "Param #{param_number}, #{param.name}, should be named context:"
+          end
+        end
+
+        def allowed_names
+          [ :context ]
+        end
+      end
+
+      class ThreeArgMethod < TwoArgMethod
+        def initialize(params)
+          super(params)
+          require_keyword(3,params[2])
+        end
+      private
+        def allowed_names
+          [ :context, :page ]
+        end
+      end
+
+    end
+
+    class GoodParams < CustomClueMethodAnalysis
+      def raise_exception!
+        raise StandardError.new("You should not have called .exception on a #{self.class.name}")
+      end
+    end
+
+    class RequiresPageObject < CustomClueMethodAnalysis
+      def requires_page_object?
+        true
+      end
+    end
+
+    class StandardImplementation < CustomClueMethodAnalysis
+      def standard_implementation?
+        true
+      end
+    end
+
+    class BadParams < CustomClueMethodAnalysis
+      def initialize(errors)
+        @message = errors.empty? ? DEFAULT_ERROR : errors.join(", ")
+      end
+
+      DEFAULT_ERROR = "dump must take one required param, one keyword param named context: and an optional keyword param named page:"
+
+      def raise_exception!
+        raise NameError.new(@message)
+      end
+    end
+  end
+end

--- a/spec/custom_clues_spec.rb
+++ b/spec/custom_clues_spec.rb
@@ -13,7 +13,14 @@ RSpec.describe "custom clues" do
     end
   end
 
+  class MyCustomClueThatNeedsThePage
+    def dump(notifier, context:, page:)
+      notifier.notify "YUP"
+    end
+  end
+
   WithClues::Method.use_custom_clue(MyCustomClue)
+  WithClues::Method.use_custom_clue(MyCustomClueThatNeedsThePage)
 
   let(:fake_stdout) { StringIO.new }
   before do
@@ -23,15 +30,125 @@ RSpec.describe "custom clues" do
 
   after do
     $stdout = @stdout
-    undef page rescue nil
   end
 
-  it "includes my custom clue on a test failure" do
-    expect {
-      with_clues do
-        expect(true).to eq(false)
+  context "clues that won't work" do
+    context "no dump method" do
+      it "raises an error" do
+        clazz = Class.new
+        expect {
+          WithClues::Method.use_custom_clue(clazz)
+        }.to raise_error(NameError,/undefined method.*dump/)
       end
-    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-    expect(fake_stdout.string).to match(/\[ with_clues \] OH YEAH/)
+    end
+    context "has a dump method" do
+      context "takes one arg" do
+        it "raises an error" do
+          clazz = Class.new
+          clazz.define_method(:dump) do |x|
+          end
+          expect {
+            WithClues::Method.use_custom_clue(clazz)
+          }.to raise_error(NameError,/dump must take one required param, one keyword param named context: and an optional keyword param named page:/)
+        end
+      end
+      context "takes 2 args" do
+        context "second arg is context:" do
+          it "works" do
+            clazz = Class.new
+            clazz.define_method(:dump) do |x, context: |
+            end
+            expect {
+              WithClues::Method.use_custom_clue(clazz)
+            }.not_to raise_error
+          end
+        end
+        context "second arg is not context:" do
+          it "raises an error" do
+            clazz = Class.new
+            clazz.define_method(:dump) do |x, not_context: |
+            end
+            expect {
+              WithClues::Method.use_custom_clue(clazz)
+            }.to raise_error(NameError,/not_context:/)
+          end
+        end
+      end
+      context "takes 3 args" do
+        context "third arg is page:" do
+          it "works" do
+            clazz = Class.new
+            clazz.define_method(:dump) do |x, context: , page:|
+            end
+            expect {
+              WithClues::Method.use_custom_clue(clazz)
+            }.not_to raise_error
+          end
+        end
+        context "second arg is page:, third is context:" do
+          it "works" do
+            clazz = Class.new
+            clazz.define_method(:dump) do |x, page:, context: |
+            end
+            expect {
+              WithClues::Method.use_custom_clue(clazz)
+            }.not_to raise_error
+          end
+        end
+        context "third arg is not page:" do
+          it "raises an error" do
+            clazz = Class.new
+            clazz.define_method(:dump) do |x, page:, foo: |
+            end
+            expect {
+              WithClues::Method.use_custom_clue(clazz)
+            }.to raise_error(NameError,/foo:/)
+          end
+        end
+      end
+      context "takes 4 args" do
+        it "raises an error" do
+          clazz = Class.new
+          clazz.define_method(:dump) do |x, page:, foo:, bar: |
+          end
+          expect {
+            WithClues::Method.use_custom_clue(clazz)
+          }.to raise_error(NameError,/dump must take one required param, one keyword param named context: and an optional keyword param named page:/)
+        end
+      end
+    end
+  end
+
+  context "not in a browser context" do
+    it "includes only the non-browser custom clue on a test failure" do
+      expect {
+        with_clues do
+          expect(true).to eq(false)
+        end
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      expect(fake_stdout.string).to     match(/\[ with_clues \] OH YEAH/)
+      expect(fake_stdout.string).not_to match(/\[ with_clues \] YUP/)
+    end
+  end
+  context "in a browser context" do
+    before do
+      Object.define_method(:page) do
+        Object.new
+      end
+    end
+
+    after do
+      Object.remove_method(:page)
+    end
+
+    it "includes the browser custom clue as well on a test failure" do
+      expect {
+        with_clues do
+          expect(true).to eq(false)
+        end
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      expect(fake_stdout.string).to match(/\[ with_clues \] OH YEAH/)
+      expect(fake_stdout.string).to match(/\[ with_clues \] YUP/)
+    end
   end
 end

--- a/spec/with_clues_spec.rb
+++ b/spec/with_clues_spec.rb
@@ -134,27 +134,63 @@ RSpec.describe WithClues::Method do
               end
             end
             context "but browser does not respond to manage" do
-              it "raises and prints a warning" do
-                def page
-                  OpenStruct.new(
-                    html: "some html",
-                    driver: OpenStruct.new(
-                      browser: OpenStruct.new()
+              context "yet it responds to logs" do
+                it "dumps the logs" do
+                  def page
+                    logs = LogsFromSomeBrowser.new([
+                      "log line 1",
+                      "log line 2",
+                      "log line 3",
+                    ])
+                    OpenStruct.new(
+                      html: "some html",
+                      driver: OpenStruct.new(
+                        browser: OpenStruct.new(
+                          logs: logs
+                        )
+                      )
                     )
-                  )
-                end
-                expect {
-                  with_clues do
-                    expect(true).to eq(false)
                   end
-                }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-                aggregate_failures do
-                  expect(fake_stdout.string).to match(/NO BROWSER LOGS/)
-                  expect(fake_stdout.string).to match(/#{page.driver.browser.class}/)
-                  expect(fake_stdout.string).to match(/does not respond to #manage/)
-                  expect(fake_stdout.string).to match(/\[ with_clues \] HTML \{/)
-                  expect(fake_stdout.string).to match(/\[ with_clues \] \} END HTML/)
-                  expect(fake_stdout.string).to match(/some html/)
+                  expect {
+                    with_clues do
+                      expect(true).to eq(false)
+                    end
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+                  aggregate_failures do
+                    expect(fake_stdout.string).to match(/\[ with_clues \] BROWSER LOGS \{/)
+                    expect(fake_stdout.string).to match(/\[ with_clues \] \} END BROWSER LOGS/)
+                    expect(fake_stdout.string).to match(/log line 1/)
+                    expect(fake_stdout.string).to match(/log line 2/)
+                    expect(fake_stdout.string).to match(/log line 3/)
+                    expect(fake_stdout.string).to match(/\[ with_clues \] HTML \{/)
+                    expect(fake_stdout.string).to match(/\[ with_clues \] \} END HTML/)
+                    expect(fake_stdout.string).to match(/some html/)
+                  end
+                end
+              end
+              context "and it does not respond to logs" do
+                it "raises and prints a warning" do
+                  def page
+                    OpenStruct.new(
+                      html: "some html",
+                      driver: OpenStruct.new(
+                        browser: OpenStruct.new()
+                      )
+                    )
+                  end
+                  expect {
+                    with_clues do
+                      expect(true).to eq(false)
+                    end
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+                  aggregate_failures do
+                    expect(fake_stdout.string).to match(/NO BROWSER LOGS/)
+                    expect(fake_stdout.string).to match(/#{page.driver.browser.class}/)
+                    expect(fake_stdout.string).to match(/does not respond to #manage/)
+                    expect(fake_stdout.string).to match(/\[ with_clues \] HTML \{/)
+                    expect(fake_stdout.string).to match(/\[ with_clues \] \} END HTML/)
+                    expect(fake_stdout.string).to match(/some html/)
+                  end
                 end
               end
             end


### PR DESCRIPTION
# Problem

Some versions of Selenium & Chromdriver store the logs from `console.log` in different places.

## Meta-problem

The `use_custom_clue` did not allow for custom clues that work in a browser context with access to the `page` object, which would've been
helpful in diagnosing this issue.

# Solution(s)

* Allow custom clues for both non-browser and browser contexts:
  - `dump(notifier, context:)` - Works as current version, used in all contexts
  - `dump(notifier, context:, page:)` - By detecting the `page:` keyword arg, will use this in a browser context, passing in `page` if `page` is available (this is how the internal browser-based clues work).
* If the old way of finding `logs` didn't work from `page.driver`, try a different way. Ugh.
