### PR TITLE
support for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Suppose you have this:
 expect(page).to have_content("My Awesome Site")
 ```
 
-And Capybara says that that content is not there and that is all it says.  You might slap in a `puts page.html` and try again.
-Instead, what if you could not do that and do this?
+And Capybara says that that content is not there and that is all it says.  You might slap in a `puts page.html` and try again. Instead, what if you could not do that and do this?
 
 ```ruby
 with_clues do
@@ -71,8 +70,7 @@ end
 
 ## Use
 
-In general, you would not want to wrap all tests with `with_clues`.  This is a diagnostic tool to allow you to get more
-information on a test that is failing.  As such, your workflow might be:
+In general, you would not want to wrap all tests with `with_clues`.  This is a diagnostic tool to allow you to get more information on a test that is failing.  As such, your workflow might be:
 
 1. Notice a test failing that you cannot easily diagnose
 1. Wrap the failing assertion in `with_clues`:
@@ -89,8 +87,10 @@ information on a test that is failing.  As such, your workflow might be:
 
 There are three clues included:
 
-* Dumping HTML - when `page` exists, it will dump the contents of `page.html` when the test fails
-* Dumping Browser logs - for a browser-based test, it will dump anything that was `console.log`'ed
+* Dumping HTML - when `page` exists, it will dump the contents of `page.html` (for Selenium) or `page.content`
+(for Playwright) when the test fails
+* Dumping Browser logs - for a browser-based test, it will dump anything that was `console.log`'ed. This should
+work with Selenium and Playwright
 * Arbitrary context you pass in, for example when testing an Active Record
 
   ```ruby
@@ -107,15 +107,16 @@ There are three clues included:
 `with_clues` is intended as a diagnostic tool you can develop and enhance over time.  As your team writes more code or develops
 more conventions, you can develop diagnostics as well.
 
-To add one, create a class that implements `dump(notifier, context:)` or `dump(notifier, context:, page:)`:
+To add one, create a class that implements `dump(notifier, context:)` or `dump(notifier, context:, page:)` or
+`dump(notifier, context:, page:, captured_logs)`:
 
-* `notifier` is a `WithClues::Notifier` that you should use to produce output:
-  * `notify` - output text, preceded with `[ with_clues ]` (this is so you can tell output from your code vs from `with_clues`)
-  * `blank_line` - a blank line (no prefix)
-  * `notify_raw` - output text without a prefix, useful for removing ambiguity about what is being output
+* `notifier` is a `WithClues::Notifier` that you should use to produce output via the following methods:
+  * `notifier.notify` - output text, preceded with `[ with_clues ]` (this is so you can tell output from your code vs from `with_clues`)
+  * `notifier.blank_line` - a blank line (no prefix)
+  * `notifier.notify_raw` - output text without a prefix, useful for removing ambiguity about what is being output
 * `context:` the context passed into `with_clues` (nil if it was omitted)
-* `page:` If `dump` requires this keyword, your clue will only be used in a browser context when the Capybara `page` object is available.
-In that case, that is what is passed in.
+* `page:` will be given the Selenium or Playwright page object
+* `captured_logs:` for Playwright, this will be the browser console logs captured inside the block
 
 For example, suppose you want to output information about an Active Record like so:
 

--- a/lib/with_clues/browser_logs.rb
+++ b/lib/with_clues/browser_logs.rb
@@ -1,6 +1,6 @@
 module WithClues
   class BrowserLogs
-    def dump(notifier, page:, context:)
+    def dump(notifier, page:, context:, captured_logs: [])
       if !page.respond_to?(:driver)
         notifier.notify "Something may be wrong. page (#{page.class}) does not respond to #driver"
         return

--- a/lib/with_clues/html.rb
+++ b/lib/with_clues/html.rb
@@ -1,18 +1,31 @@
 module WithClues
   class Html
-    def dump(notifier, page:, context:)
+    def dump(notifier, page:, context:, captured_logs: [])
+      access_page_html = if page.respond_to?(:html)
+                           ->(page) { page.html }
+                         elsif page.respond_to?(:content)
+                           ->(page) { page.content }
+                         elsif page.respond_to?(:native)
+                           ->(page) { page.native }
+                         else
+                           notifier.notify "Something may be wrong. page (#{page.class}) does not respond to #html, #native, or #content"
+                           return
+                         end
       notifier.blank_line
       notifier.notify "HTML {"
       notifier.blank_line
-      if page.respond_to?(:html)
-        notifier.notify_raw page.html
-      elsif page.respond_to?(:native)
-        notifier.notify_raw page.native
-      else
-        notifier.notify "[!] Something may be wrong. page (#{page.class}) does not respond to #html or #native"
-      end
+      notifier.notify_raw access_page_html.(page)
       notifier.blank_line
       notifier.notify "} END HTML"
+      if captured_logs.any?
+        notifier.notify "LOGS {"
+        notifier.blank_line
+        captured_logs.each do |log|
+          notifier.notify_raw log
+        end
+        notifier.blank_line
+        notifier.notify "} END LOGS"
+      end
     end
   end
 end

--- a/lib/with_clues/version.rb
+++ b/lib/with_clues/version.rb
@@ -1,3 +1,3 @@
 module WithClues
-  VERSION="1.2.0"
+  VERSION="1.3.0"
 end

--- a/spec/custom_clues_spec.rb
+++ b/spec/custom_clues_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "custom clues" do
   end
 
   class MyCustomClueThatNeedsThePage
-    def dump(notifier, context:, page:)
+    def dump(notifier, context:, page:, captured_logs:)
       notifier.notify "YUP"
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe "custom clues" do
           end
           expect {
             WithClues::Method.use_custom_clue(clazz)
-          }.to raise_error(NameError,/dump must take one required param, one keyword param named context: and an optional keyword param named page:/)
+          }.to raise_error(NameError,/accepted 1 arguments, not 2 or 4/)
         end
       end
       context "takes 2 args" do
@@ -74,21 +74,21 @@ RSpec.describe "custom clues" do
           end
         end
       end
-      context "takes 3 args" do
-        context "third arg is page:" do
+      context "takes 4 args" do
+        context "third arg is page: and fourth is captured_logs:" do
           it "works" do
             clazz = Class.new
-            clazz.define_method(:dump) do |x, context: , page:|
+            clazz.define_method(:dump) do |x, context: , page:, captured_logs:|
             end
             expect {
               WithClues::Method.use_custom_clue(clazz)
             }.not_to raise_error
           end
         end
-        context "second arg is page:, third is context:" do
+        context "second arg is page:, third is context: and fourth is captured_logs:" do
           it "works" do
             clazz = Class.new
-            clazz.define_method(:dump) do |x, page:, context: |
+            clazz.define_method(:dump) do |x, page:, context:, captured_logs:|
             end
             expect {
               WithClues::Method.use_custom_clue(clazz)
@@ -98,7 +98,7 @@ RSpec.describe "custom clues" do
         context "third arg is not page:" do
           it "raises an error" do
             clazz = Class.new
-            clazz.define_method(:dump) do |x, page:, foo: |
+            clazz.define_method(:dump) do |x, page:, foo:, captured_logs: |
             end
             expect {
               WithClues::Method.use_custom_clue(clazz)
@@ -106,14 +106,14 @@ RSpec.describe "custom clues" do
           end
         end
       end
-      context "takes 4 args" do
+      context "takes 3 args" do
         it "raises an error" do
           clazz = Class.new
-          clazz.define_method(:dump) do |x, page:, foo:, bar: |
+          clazz.define_method(:dump) do |x, page:, context:|
           end
           expect {
             WithClues::Method.use_custom_clue(clazz)
-          }.to raise_error(NameError,/dump must take one required param, one keyword param named context: and an optional keyword param named page:/)
+          }.to raise_error(NameError,/accepted 3 arguments, not 2 or 4/)
         end
       end
     end

--- a/with_clues.gemspec
+++ b/with_clues.gemspec
@@ -1,13 +1,11 @@
 require_relative "lib/with_clues/version"
 
-#require_relative "lib/«gem»/version"
-
 Gem::Specification.new do |spec|
   spec.name = "with_clues"
   spec.version = WithClues::VERSION
   spec.authors       = ["Dave Copeland"]
   spec.email         = ["davec@naildrivin5.com"]
-  spec.summary       = %q{WTF does this do?}
+  spec.summary       = %q{Temporarily add context to failing tests to get more information, such as what HTML was being examined when a browser-based test fails.}
   spec.homepage      = "https://sustainable-rails.com"
   spec.license       = "Hippocratic"
 


### PR DESCRIPTION
# Problem

Playwright's `page` object doesn't produce HTML from the `html` method, but instead uses `content`.  Why can't all
these libraries use `outerHTML` or something remotely related to the browser spec?

Also, Playwright makes `console.log` statements available based on an evented construct.

# Solution

Allow `page.content` to be checked before giving up on HTML.  Plus, if `page` responds to `on`, use that to listen to
any log messages produced and, if any where produced, output them with the clue.
